### PR TITLE
EARTH-83: Removed default display of poster.

### DIFF
--- a/config/install/node.type.complex_page.yml
+++ b/config/install/node.type.complex_page.yml
@@ -26,4 +26,4 @@ description: 'A long form story telling page.'
 help: ''
 new_revision: true
 preview_mode: 1
-display_submitted: true
+display_submitted: false


### PR DESCRIPTION
# READY FOR REVIEW

# Summary
Removes the silly 'posted by admin on Tues... " text.

# Needed By (Date)
- June 2nd

# Urgency
- Not very.

# Steps to Test

- Refresh local environment `blt local:refresh`
- View home page with submitted text on it
- Checkout this branch
- Import feature configuration `drush features-import-all`
- Clear cache
- View home page with no text

# Affected Projects or Products
- Just earth

# Associated Issues and/or People
- EARTH-84

# See Also
- [PR Checklist](https://gist.github.com/sherakama/0ba17601381e3adbe0cad566ad4d80a5)