### PR TITLE
EARTH-193: Updates to default settings.

### DIFF
--- a/config/install/field.field.node.complex_page.field_component.yml
+++ b/config/install/field.field.node.complex_page.field_component.yml
@@ -20,5 +20,5 @@ settings:
   handler: 'default:paragraph'
   handler_settings:
     target_bundles: null
-    target_bundles_drag_drop: { }
+    target_bundles_drag_drop: {  }
 field_type: entity_reference_revisions

--- a/config/install/node.type.complex_page.yml
+++ b/config/install/node.type.complex_page.yml
@@ -12,14 +12,14 @@ third_party_settings:
   scheduler:
     expand_fieldset: when_required
     fields_display_mode: vertical_tab
-    publish_enable: false
+    publish_enable: true
     publish_past_date: error
     publish_required: false
-    publish_revision: false
+    publish_revision: true
     publish_touch: false
-    unpublish_enable: false
+    unpublish_enable: true
     unpublish_required: false
-    unpublish_revision: false
+    unpublish_revision: true
 name: 'Complex Page'
 type: complex_page
 description: 'A long form story telling page.'

--- a/config/install/simple_sitemap.bundle_settings.node.complex_page.yml
+++ b/config/install/simple_sitemap.bundle_settings.node.complex_page.yml
@@ -1,0 +1,2 @@
+index: 1
+priority: '0.5'


### PR DESCRIPTION
# READY FOR REVIEW

# Summary

Please review all 5 PRs at once:
- https://github.com/SU-SWS/stanford_paragraph_types/pull/34
- https://github.com/SU-SWS/stanford_components/pull/8
- https://github.com/SU-SWS/stanford_complex_page/pull/3
- https://github.com/stanford-earth/matson/pull/23/files
- https://github.com/stanford-earth/SE3_BLT/pull/8/files

The above 5 PRs do the following
- Implements the hero banner for complex page.
- Removes page title on node types
- Removes old testing hero paragraph type
- Creates new hero banner paragraph type
- Adds new css for hero banners so they have the correct placement under the menu
- Adds css for the edit tabs so they don't get lost
- Enables new hero banner paragraph type module
- Enables scheduled publishing and unpublishing on complex page type
- Enables xml sitemap for complex page content type

# Needed By (Date)
- Soonish would be better. Nick wants to build out stuff.

# Urgency
- Moderate

# Steps to Test

1. Check out all of the above branches. They should all be named hero-banner
2. Do a local refresh
3. validate the above list of changes
4. Create and place a new hero banner paragraph type

# Associated Issues and/or People
- EARTH-139

# See Also
- [PR Checklist](https://gist.github.com/sherakama/0ba17601381e3adbe0cad566ad4d80a5)