### PR TITLE
Collapse paragraphs by default to make edit screen moar better.

### DIFF
--- a/config/install/core.entity_form_display.node.complex_page.default.yml
+++ b/config/install/core.entity_form_display.node.complex_page.default.yml
@@ -25,10 +25,10 @@ content:
     settings:
       title: Paragraph
       title_plural: Paragraphs
-      edit_mode: open
+      edit_mode: closed
       add_mode: dropdown
       form_display_mode: default
-      default_paragraph_type: ''
+      default_paragraph_type: _none
     third_party_settings: {  }
     region: content
   path:
@@ -50,6 +50,11 @@ content:
     settings: {  }
     third_party_settings: {  }
     region: content
+  scheduler_settings:
+    weight: 20
+    region: content
+    settings: {  }
+    third_party_settings: {  }
   sticky:
     type: boolean_checkbox
     settings:


### PR DESCRIPTION
# READY FOR REVIEW

# Summary
- Sets the complex page paragraph field to collapsed by default.

# Needed By (Date)
- Sometime before July release.

# Urgency
- Nice to have

# Steps to Test

1.  Checkout this branch
2. Import feature
3. Clear cache
4. Edit a complex page and ensure paragraphs are collapsed.

# Associated Issues and/or People
- EARTH

# See Also
- [PR Checklist](https://gist.github.com/sherakama/0ba17601381e3adbe0cad566ad4d80a5)