### PR TITLE
EARTH-514 Uses a simple pattern to eliminate uneccessary divs

### DIFF
--- a/config/install/core.entity_view_display.node.complex_page.default.yml
+++ b/config/install/core.entity_view_display.node.complex_page.default.yml
@@ -5,8 +5,22 @@ dependencies:
     - field.field.node.complex_page.field_component
     - node.type.complex_page
   module:
+    - ds
     - entity_reference_revisions
     - user
+third_party_settings:
+  ds:
+    layout:
+      id: pattern_simple
+      library: null
+      disable_css: false
+      entity_classes: all_classes
+      settings:
+        pattern:
+          field_templates: only_content
+    regions:
+      content:
+        - field_component
 id: node.complex_page.default
 targetEntityType: node
 bundle: complex_page


### PR DESCRIPTION
# READY FOR REVIEW

# Summary
- Use a simple pattern so that we can set it to fields only without the extra wrapping divs. This helps to put each paragraph in the same level of html - allowing us to target the first hero of any paragraph.

# Needed By (Date)
- Soon

# Urgency
- medium

# Steps to Test

1. Checkout this branch and same branch name of [stanford_components](https://github.com/SU-SWS/stanford_components/pull/91) and [matson](https://github.com/stanford-earth/matson/pull/81)
2. `drush cr; drush features-import stanford_complex_page -y`
3. create a complex page with a video paragraph item.
4. put it at the top with full width - make sure it gets pulled to the top of the page.
5. Put it at the top but not full width - make sure it is below the top banner portion
6. Put it in the middle of the page full width and not full width - make sure it doesnt get the negative top margin
7. review these in mobile. ( not sure what to do about top hero when in mobile.)
8. do happy dance.

# Associated Issues and/or People
- https://github.com/stanford-earth/matson/pull/81
- https://github.com/SU-SWS/stanford_components/pull/91

# See Also
- [PR Checklist](https://gist.github.com/sherakama/0ba17601381e3adbe0cad566ad4d80a5)